### PR TITLE
feat: adiciona componente Novidade

### DIFF
--- a/src/components/Novidade.tsx
+++ b/src/components/Novidade.tsx
@@ -1,0 +1,100 @@
+import React, { FC, useEffect, useState } from 'react'
+import { makeStyles, createStyles } from '@material-ui/core/styles'
+import Alert from '@material-ui/lab/Alert'
+import { AlertTitle } from '@material-ui/lab'
+import { Collapse } from '@material-ui/core'
+import DispensarNovidade from 'src/services/user/DispensarNovidade'
+import theme from '../../theme'
+import { IUser } from 'src/entities/User'
+
+const useStyles = makeStyles(() =>
+  createStyles({
+    hiddenCollapse: {
+      display: 'none'
+    },
+    root: {
+      maxWidth: 335,
+      margin: '0 auto',
+      padding: '6px 12px',
+      background: 'linear-gradient(95.27deg, #4237BF 0.47%, #9C37BF 100.56%)',
+      borderRadius: 10,
+      color: '#FFF',
+      fontSize: 16
+    },
+    alertTitle: {
+      display: 'flex',
+      justifyContent: 'space-between',
+      alignItems: 'center',
+      fontWeight: 700
+    },
+    destaque: {
+      width: 46,
+      height: 16,
+      display: 'flex',
+      alignItems: 'center',
+      justifyContent: 'center',
+      borderRadius: 10,
+      background: theme.palette.primary.main,
+      color: theme.palette.secondary.main,
+      fontWeight: 800,
+      fontSize: 8,
+      textTransform: 'uppercase',
+      lineHeight: '11px'
+    },
+    action: {
+      alignItems: 'flex-start'
+    }
+  })
+)
+
+interface IProps {
+  slug: string
+  user: IUser
+}
+
+const Novidade: FC<IProps> = ({ user, slug }) => {
+  const classes = useStyles()
+  const [visivel, setVisivel] = useState(false)
+  const titulo = 'Crie hábitos personalizados!'
+  const descricao =
+    'Arraste até o final da lista para criar novos hábitos de sua preferência 🙌'
+
+  useEffect(() => {
+    const verificarNovidade = async () => {
+      const novidadeNaoDispensada = !user.novidadeDispensada(slug)
+      setVisivel(novidadeNaoDispensada)
+      if (novidadeNaoDispensada) {
+        await new DispensarNovidade().call(slug, user)
+      }
+    }
+    verificarNovidade()
+  }, [])
+
+  const handleOnClose = async () => {
+    setVisivel(false)
+  }
+
+  return (
+    <Collapse
+      in={visivel}
+      className={!visivel ? `${classes.hiddenCollapse}` : ''}
+    >
+      <Alert
+        onClose={handleOnClose}
+        icon={<></>}
+        classes={{
+          root: classes.root,
+          action: classes.action
+        }}
+      >
+        <AlertTitle className={classes.alertTitle}>
+          {titulo}
+          <div className={classes.destaque}>Novo</div>
+        </AlertTitle>
+        {descricao}
+      </Alert>
+    </Collapse>
+  )
+}
+
+export default Novidade

--- a/src/components/hocs/withAuth.tsx
+++ b/src/components/hocs/withAuth.tsx
@@ -30,11 +30,9 @@ const withAuth = ({ type }: withAuthParams) => (
           const getUser = async () => {
             try {
               const newUser = await new GetUserById().call(user.uid)
-              console.log('usuario logado', newUser)
               setUser(newUser)
               setLoading(false)
             } catch (e) {
-              console.log('erro ao trazer usuario', e)
               setUser(null)
               setLoading(false)
             }
@@ -73,7 +71,12 @@ const withAuth = ({ type }: withAuthParams) => (
     return (
       <>
         <Alert />
-        <WrappedComponent userId={user?.id} userName={user?.nome} {...props} />
+        <WrappedComponent
+          userId={user?.id}
+          userName={user?.nome}
+          user={user}
+          {...props}
+        />
       </>
     )
   }

--- a/src/entities/User.ts
+++ b/src/entities/User.ts
@@ -8,6 +8,8 @@ interface IUserAttributes {
   objetivos: Array<string>
   temLivro: TemLivroOptions
   role?: string
+  novidadesDispensadas?: Array<string>
+  novidadeDispensada?(slug: string): boolean
 }
 
 export type IUser = IUserAttributes
@@ -20,6 +22,7 @@ export default class User implements IUser {
   public objetivos: Array<string>
   public temLivro: TemLivroOptions
   public role: string
+  public novidadesDispensadas: Array<string>
 
   constructor({
     id,
@@ -28,7 +31,8 @@ export default class User implements IUser {
     password,
     objetivos,
     temLivro,
-    role
+    role,
+    novidadesDispensadas
   }: IUserAttributes) {
     this.id = id
     this.nome = nome
@@ -37,5 +41,10 @@ export default class User implements IUser {
     this.objetivos = objetivos
     this.temLivro = temLivro
     this.role = role
+    this.novidadesDispensadas = novidadesDispensadas
+  }
+
+  novidadeDispensada(slug: string): boolean {
+    return this.novidadesDispensadas.includes(slug)
   }
 }

--- a/src/factories/UserFactory.ts
+++ b/src/factories/UserFactory.ts
@@ -13,7 +13,8 @@ export default class UserFactory {
       password,
       temLivro,
       objetivos,
-      role
+      role,
+      novidadesDispensadas
     } = userSnapshot.data()
 
     return new User({
@@ -23,7 +24,8 @@ export default class UserFactory {
       password,
       temLivro,
       objetivos,
-      role
+      role,
+      novidadesDispensadas: novidadesDispensadas || []
     })
   }
 }

--- a/src/pages/app/diario/[date]/habitos/index.tsx
+++ b/src/pages/app/diario/[date]/habitos/index.tsx
@@ -12,6 +12,8 @@ import HabitosCheckboxGroup, {
 } from '../../../../../components/diario/HabitosCheckboxGroup'
 import { useRouter } from 'next/router'
 import { analytics } from '../../../../../components/firebase/firebase.config'
+import Novidade from '../../../../../components/Novidade'
+import { IUser } from 'src/entities/User'
 
 const useStyles = makeStyles(() =>
   createStyles({
@@ -25,14 +27,15 @@ const useStyles = makeStyles(() =>
 )
 
 interface IProps {
-  userId?: string
   date: string
+  user: IUser
 }
 
-const Habitos: FC<IProps> = ({ userId, date }) => {
+const Habitos: FC<IProps> = ({ date, user }) => {
   const classes = useStyles()
   const dia = parse(date, 'd-M-yyyy', new Date())
   const router = useRouter()
+  const userId = user?.id
 
   const { loading, registroDoDia } = useRegistroByDate({
     userId,
@@ -63,6 +66,7 @@ const Habitos: FC<IProps> = ({ userId, date }) => {
 
   return (
     <EdicaoDiario date={date} onClick={onSalvarClick} loading={loading}>
+      <Novidade slug="habitos-personalizados" user={user} />
       <Box mt="46px" maxWidth={360} ml="28px">
         <HabitosCheckboxGroup
           onChange={setGruposDeHabitos}

--- a/src/repositories/UsersRepository.ts
+++ b/src/repositories/UsersRepository.ts
@@ -16,9 +16,15 @@ interface ICreateParameters {
   gruposDeHabitos: Array<IGrupoDeHabitos>
 }
 
+interface IUpdateParameters {
+  id: string
+  attributes: string
+}
+
 export interface IUsersRepository {
   add(params): Promise<IUser>
   getById(id: string): Promise<IUser>
+  update(params): boolean
 }
 
 export default class UsersRepository implements IUsersRepository {
@@ -77,6 +83,15 @@ export default class UsersRepository implements IUsersRepository {
       return user
     } catch (e) {
       throw new Error('Ocorreu um erro inesperado ao buscar o usuário:' + e)
+    }
+  }
+
+  update({ id, attributes }: IUpdateParameters): boolean {
+    try {
+      this.collection.doc(id).update(attributes)
+      return true
+    } catch (e) {
+      throw new Error('Ocorreu um erro inesperado ao atualizar usuário.' + e)
     }
   }
 }

--- a/src/services/user/DispensarNovidade.ts
+++ b/src/services/user/DispensarNovidade.ts
@@ -1,0 +1,26 @@
+import { IUser } from 'src/entities/User'
+import UsersRepository, {
+  IUsersRepository
+} from '../../repositories/UsersRepository'
+
+interface IDispensarNovidade {
+  call(slug: string, user: IUser): boolean
+}
+
+export default class DispensarNovidade implements IDispensarNovidade {
+  private usersRepository: IUsersRepository
+
+  constructor() {
+    this.usersRepository = new UsersRepository()
+  }
+
+  call(slug: string, user: IUser): boolean {
+    const id = user?.id
+    const novidadesDispensadas = [...user.novidadesDispensadas, slug]
+
+    return this.usersRepository.update({
+      id,
+      attributes: { novidadesDispensadas: novidadesDispensadas }
+    })
+  }
+}


### PR DESCRIPTION
### Como está funcionado:

- Ao acessar a página de edição de hábitos a alerta de Novidade será exibido. 
- Ao montar o componente o service para dispensar a novidade é chamado adicionando no array novidadesDispensadas o slug da novidade. Da próxima vez que o usuário acessar se o slug estiver no array a novidade não é mais exibida.

![image](https://user-images.githubusercontent.com/13313889/117828854-9b6e0400-b248-11eb-8b07-187d2309c3bd.png)

#### TO-DO
Uma ideia seria ter uma collection de "Novidades" com titulo, descrição, slug, path, uma data de início e fim pra ser exibida, pra que esses alertar possam ser personalizados e adicionados pelos administradores. Mas deixei pra vermos isso no futuro, em outra tarefa.

Closes #177948079