### PR TITLE
feat: edição hábitos personalizados

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -6,16 +6,3 @@ module.exports = withPWA({
     scope: '/app'
   }
 })
-
-// TODO: Remover quando a funcionalidade de novos hábitos estiver disponível
-module.exports = {
-  async redirects() {
-    return [
-      {
-        source: '/app/diario/:date/habitos/novo',
-        destination: '/',
-        permanent: true,
-      },
-    ]
-  },
-}

--- a/src/components/diario/HabitoForm.tsx
+++ b/src/components/diario/HabitoForm.tsx
@@ -1,0 +1,86 @@
+import React, { FC, useState, useEffect, ReactElement } from 'react'
+import { Box } from '@material-ui/core/'
+import TextField from '../TextField'
+import Titulo from '../Titulo'
+import InputLabel from '../InputLabel'
+import { useRouter } from 'next/dist/client/router'
+import Layout from '../templates/Layout'
+import CreateHabito from '../../services/habito/CreateHabito'
+import EmojiToUnicode from 'src/services/EmojiToUnicode'
+import { IHabito } from 'src/entities/Habito'
+import UpdateHabito from 'src/services/habito/UpdateHabito'
+
+interface IProps {
+  userId?: string
+  date: string
+  habito?: IHabito
+  formTitulo: ReactElement | string
+}
+
+const HabitoForm: FC<IProps> = ({ userId, date, habito, formTitulo }) => {
+  const [emoji, setEmoji] = useState(habito?.emoji || '')
+  const [emojiUnicode, setEmojiUnicode] = useState(habito?.emojiUnicode || [])
+  const [nome, setNome] = useState(habito?.nome || '')
+  const [error, setErrors] = useState('')
+  const router = useRouter()
+
+  useEffect(() => {
+    setNome(habito?.nome || '')
+    setEmoji(habito?.emoji || '')
+    setEmojiUnicode(habito?.emojiUnicode || [])
+  }, [habito])
+
+  const onChangeNome = ({ target: { value } }) => {
+    setNome(value)
+  }
+
+  const onChangeEmoji = ({ target: { value } }) => {
+    setErrors('')
+    const unicodes = new EmojiToUnicode().call(value.trim().toLowerCase())
+    if (unicodes.length <= 0) {
+      setErrors('Por favor adicione um emoji')
+    }
+    setEmoji(value.trim().toLowerCase())
+    setEmojiUnicode(unicodes)
+  }
+
+  const handleCreateOrUpdate = async () => {
+    if (habito?.id) {
+      new UpdateHabito().call({ id: habito.id, nome, emojiUnicode })
+    } else {
+      new CreateHabito().call({ userId, nome, emojiUnicode })
+    }
+    router.push(`/app/diario/${date}/habitos`)
+  }
+
+  return (
+    <Layout
+      onButtonClick={handleCreateOrUpdate}
+      textoBotao="Salvar"
+      exibirBotao={emoji && nome && !error}
+    >
+      <Titulo>{formTitulo}</Titulo>
+
+      <Box mt={5}>
+        <Box>
+          <InputLabel>Emoji</InputLabel>
+          <TextField
+            value={emoji}
+            onChange={onChangeEmoji}
+            error={Boolean(error)}
+            helperText={error}
+            inputProps={{ maxLength: 2 }}
+          />
+          <InputLabel>Nome</InputLabel>
+          <TextField
+            value={nome}
+            onChange={onChangeNome}
+            inputProps={{ maxLength: 15 }}
+          />
+        </Box>
+      </Box>
+    </Layout>
+  )
+}
+
+export default HabitoForm

--- a/src/pages/app/diario/[date]/habitos/[id].tsx
+++ b/src/pages/app/diario/[date]/habitos/[id].tsx
@@ -1,0 +1,47 @@
+import React, { FC, useState, useEffect } from 'react'
+import { withUser } from 'src/components/hocs/withAuth'
+import { NextPageContext } from 'next'
+import GetHabitoById from 'src/services/habito/GetHabitoById'
+import HabitoForm from 'src/components/diario/HabitoForm'
+
+interface IProps {
+  date: string
+  id: string
+}
+
+const NovoHabito: FC<IProps> = ({ date, id }) => {
+  const [habito, setHabito] = useState(null)
+
+  useEffect(() => {
+    const buscarHabito = async () => {
+      const novoHabito = await new GetHabitoById().call(id)
+      setHabito(novoHabito)
+    }
+    buscarHabito()
+  }, [])
+
+  return (
+    <HabitoForm habito={habito} date={date} formTitulo="Edição do hábito" />
+  )
+}
+
+interface INovoHabitoWithAuthProps {
+  date: string
+  id: string
+}
+
+const NovoHabitoWithAuth = withUser(NovoHabito)
+
+NovoHabitoWithAuth.getInitialProps = (
+  context: NextPageContext
+): INovoHabitoWithAuthProps => {
+  const date = context.query.date as string
+  const id = context.query.id as string
+
+  return {
+    date,
+    id
+  }
+}
+
+export default NovoHabitoWithAuth

--- a/src/pages/app/diario/[date]/habitos/index.tsx
+++ b/src/pages/app/diario/[date]/habitos/index.tsx
@@ -54,7 +54,7 @@ const Habitos: FC<IProps> = ({ date, user }) => {
   return (
     <EdicaoDiario date={date} onClick={onSalvarClick} loading={loading}>
       <Novidade slug="habitos-personalizados" user={user} />
-      <Box mt="46px" maxWidth={360} ml="28px">
+      <Box mt="46px" maxWidth={360}>
         <HabitosCheckboxGroup
           onChange={setGruposDeHabitos}
           values={gruposDeHabitos}

--- a/src/pages/app/diario/[date]/habitos/index.tsx
+++ b/src/pages/app/diario/[date]/habitos/index.tsx
@@ -1,8 +1,7 @@
 import React, { FC, useEffect, useState } from 'react'
 import { NextPageContext } from 'next'
 import { parse } from 'date-fns'
-import { Box, Typography } from '@material-ui/core'
-import { makeStyles, createStyles } from '@material-ui/core/styles'
+import { Box } from '@material-ui/core'
 import { withUser } from '../../../../../components/hocs/withAuth'
 import CreateOrUpdateRegistro from '../../../../../services/registro/CreateOrUpdateRegistro'
 import EdicaoDiario from '../../../../../components/templates/EdicaoDiario'
@@ -15,24 +14,12 @@ import { analytics } from '../../../../../components/firebase/firebase.config'
 import Novidade from '../../../../../components/Novidade'
 import { IUser } from 'src/entities/User'
 
-const useStyles = makeStyles(() =>
-  createStyles({
-    textoInformativo: {
-      margin: '24px 29px',
-      width: 284,
-      color: '#BDBDBD',
-      lineHeight: '22px'
-    }
-  })
-)
-
 interface IProps {
   date: string
   user: IUser
 }
 
 const Habitos: FC<IProps> = ({ date, user }) => {
-  const classes = useStyles()
   const dia = parse(date, 'd-M-yyyy', new Date())
   const router = useRouter()
   const userId = user?.id
@@ -73,12 +60,9 @@ const Habitos: FC<IProps> = ({ date, user }) => {
           values={gruposDeHabitos}
           onAdicionarHabitoClick={handleAdicionarHabito}
           userId={userId}
+          date={date}
         />
       </Box>
-      <Typography className={classes.textoInformativo}>
-        Gostaria de editar ou incluir um novo hábito? Envie uma sugestão para
-        <span style={{ color: '#F7C92A' }}> jornadasolar@gmail.com.br</span>
-      </Typography>
     </EdicaoDiario>
   )
 }

--- a/src/pages/app/diario/[date]/habitos/novo.tsx
+++ b/src/pages/app/diario/[date]/habitos/novo.tsx
@@ -1,15 +1,8 @@
-import React, { FC, useState } from 'react'
-import { Box } from '@material-ui/core/'
-import Emoji from '../../../../../components/Emoji'
-import TextField from '../../../../../components/TextField'
-import Titulo from '../../../../../components/Titulo'
-import InputLabel from '../../../../../components/InputLabel'
-import { useRouter } from 'next/dist/client/router'
+import React, { FC } from 'react'
 import { withUser } from 'src/components/hocs/withAuth'
-import Layout from '../../../../../components/templates/Layout'
-import CreateHabito from '../../../../../services/habito/CreateHabito'
 import { NextPageContext } from 'next'
-import EmojiToUnicode from 'src/services/EmojiToUnicode'
+import HabitoForm from 'src/components/diario/HabitoForm'
+import Emoji from 'src/components/Emoji'
 
 interface IProps {
   userId?: string
@@ -17,60 +10,16 @@ interface IProps {
 }
 
 const NovoHabito: FC<IProps> = ({ userId, date }: IProps) => {
-  const [emoji, setEmoji] = useState('')
-  const [emojiUnicode, setEmojiUnicode] = useState([])
-  const [nome, setNome] = useState('')
-  const [error, setErrors] = useState('')
-  const router = useRouter()
-
-  const onChangenome = ({ target: { value } }) => {
-    setNome(value)
-  }
-
-  const onChangeEmoji = ({ target: { value } }) => {
-    setErrors('')
-    const unicodes = new EmojiToUnicode().call(value.trim().toLowerCase())
-    if (unicodes.length <= 0) {
-      setErrors('Por favor adicione um emoji')
-    }
-    setEmoji(value.trim().toLowerCase())
-    setEmojiUnicode(unicodes)
-  }
-
-  const handleAddHabito = async () => {
-    new CreateHabito().call({ userId, nome, emojiUnicode })
-    router.push(`/app/diario/${date}/habitos`)
-  }
-
   return (
-    <Layout
-      onButtonClick={handleAddHabito}
-      textoBotao="Adicionar"
-      exibirBotao={emoji && nome && !error}
-    >
-      <Titulo>
-        Adicione um hábito personalizado <Emoji nome="alegre" />
-      </Titulo>
-
-      <Box mt={5}>
-        <Box>
-          <InputLabel>Emoji</InputLabel>
-          <TextField
-            value={emoji}
-            onChange={onChangeEmoji}
-            error={Boolean(error)}
-            helperText={error}
-            inputProps={{ maxLength: 2 }}
-          />
-          <InputLabel>Nome</InputLabel>
-          <TextField
-            value={nome}
-            onChange={onChangenome}
-            inputProps={{ maxLength: 15 }}
-          />
-        </Box>
-      </Box>
-    </Layout>
+    <HabitoForm
+      date={date}
+      userId={userId}
+      formTitulo={
+        <>
+          Adicione um hábito personalizado <Emoji nome="alegre" />
+        </>
+      }
+    />
   )
 }
 

--- a/src/repositories/HabitosRepository.ts
+++ b/src/repositories/HabitosRepository.ts
@@ -12,6 +12,7 @@ export interface IHabitosRepository {
   add(params): boolean
   getAllByUserId(userId: string): Promise<Array<IHabito>>
   update(id, values): boolean
+  getById(id: string): Promise<IHabito>
 }
 
 export default class HabitosRepository implements IHabitosRepository {
@@ -62,6 +63,23 @@ export default class HabitosRepository implements IHabitosRepository {
       return habitos
     } catch (e) {
       throw new Error('Ocorreu um erro inesperado ao buscar os hábitos.')
+    }
+  }
+
+  async getById(id: string): Promise<IHabito> {
+    try {
+      const habitoSnapshot = await this.collection.doc(id).get()
+      const HabitosData = habitoSnapshot.data()
+      const habito = new Habito({
+        id: habitoSnapshot.id,
+        userId: HabitosData.userId,
+        nome: HabitosData.nome,
+        emojiUnicode: HabitosData.emojiUnicode
+      })
+
+      return habito
+    } catch (e) {
+      throw new Error('Ocorreu um erro inesperado ao buscar o hábito:' + e)
     }
   }
 }

--- a/src/services/grupoDehabitos/GetGrupoDeHabitosTemplateByUserId.ts
+++ b/src/services/grupoDehabitos/GetGrupoDeHabitosTemplateByUserId.ts
@@ -191,7 +191,7 @@ export default class GetGrupoDeHabitosTemplateByUserId implements IGetGrupoDeHab
         nome: 'Personalizados',
         habitos: habitosDoUsuario
       })
-      gruposDeHabitos.unshift(personalizados)
+      gruposDeHabitos.push(personalizados)
     }
 
     return gruposDeHabitos

--- a/src/services/habito/GetHabitoById.ts
+++ b/src/services/habito/GetHabitoById.ts
@@ -1,0 +1,20 @@
+import { IHabito } from '../../entities/Habito'
+import HabitosRepository, {
+  IHabitosRepository
+} from '../../repositories/HabitosRepository'
+
+interface IGetHabitoById {
+  call(id: string): Promise<IHabito>
+}
+
+export default class GetHabitoById implements IGetHabitoById {
+  private habitosRepository: IHabitosRepository
+
+  constructor() {
+    this.habitosRepository = new HabitosRepository()
+  }
+
+  async call(id: string): Promise<IHabito> {
+    return await this.habitosRepository.getById(id)
+  }
+}

--- a/src/services/habito/UpdateHabito.ts
+++ b/src/services/habito/UpdateHabito.ts
@@ -4,7 +4,7 @@ import HabitosRepository, {
 
 type Parameters = {
   id: string
-  emojiUnicode?: string
+  emojiUnicode?: Array<string>
   nome?: string
 }
 


### PR DESCRIPTION
O usuário consegue editar o **nome** e o **emoji** do hábito personalizado, mas não o nome do grupo (como estava no layout) porque isso ia dificultar a implementação nesse momento, e acho que podemos avaliar se realmente faz sentido editar os nomes dos grupos quando implementarmos a edição de todos os hábitos.

- feat: remove config de redirects de novos habitos
- feat: adiciona service pra buscar habito by id
- feat: exibe habitos personalizados no fim da lista
- fix(UpdateHabito): ajusta type do emojiUnicode
- feat: edição de hábitos personalizados 
- feat: remove texto sobre editar e adicionar hábito
- style(habitos): remove margin lateral

Closes #177294924