### PR TITLE
feat: Salva id do grupoDeHabito no registro

### DIFF
--- a/src/components/cadastro/EtapaHabitos.tsx
+++ b/src/components/cadastro/EtapaHabitos.tsx
@@ -1,4 +1,4 @@
-import React, { FC, useState } from 'react'
+import React, { FC, useEffect, useState } from 'react'
 import { useDispatch } from 'react-redux'
 import { bindActionCreators } from '@reduxjs/toolkit'
 import { Box } from '@material-ui/core'
@@ -6,49 +6,7 @@ import Layout from '../templates/Layout'
 import Titulo from '../Titulo'
 import HabitosCheckboxGroup from '../diario/HabitosCheckboxGroup'
 import { avancoParaEtapa5Solicitado as avancoParaEtapa5SolicitadoAction } from '../../redux/cadastro'
-
-const valoresIniciais = [
-  {
-    nome: 'social',
-    habitos: []
-  },
-  {
-    nome: 'Lazer',
-    habitos: []
-  },
-  {
-    nome: 'Atividade física',
-    habitos: []
-  },
-  {
-    nome: 'sono',
-    habitos: []
-  },
-  {
-    nome: 'Alimentação',
-    habitos: []
-  },
-  {
-    nome: 'Saúde',
-    habitos: []
-  },
-  {
-    nome: 'Profissional',
-    habitos: []
-  },
-  {
-    nome: 'Tarefa',
-    habitos: []
-  },
-  {
-    nome: 'Sexo',
-    habitos: []
-  },
-  {
-    nome: 'Vício',
-    habitos: []
-  }
-]
+import { getGrupoDeHabitosIniciais } from 'src/utils/getGrupoDeHabitosIniciais'
 
 const EtapaHabitos: FC = () => {
   const dispatch = useDispatch()
@@ -57,7 +15,15 @@ const EtapaHabitos: FC = () => {
     dispatch
   )
 
-  const [gruposDeHabitos, setGruposDeHabitos] = useState(valoresIniciais)
+  const [gruposDeHabitos, setGruposDeHabitos] = useState([])
+
+  useEffect(() => {
+    const buscarValoresIniciais = async () => {
+      const valoresIniciais = await getGrupoDeHabitosIniciais()
+      setGruposDeHabitos(valoresIniciais)
+    }
+    buscarValoresIniciais()
+  }, [])
 
   const handleOnClickButton = () => {
     avancoParaEtapa5Solicitado({ gruposDeHabitos })

--- a/src/components/diario/HabitosCheckboxGroup.tsx
+++ b/src/components/diario/HabitosCheckboxGroup.tsx
@@ -100,53 +100,6 @@ const useStyles = makeStyles(() =>
   })
 )
 
-export const valoresIniciais = [
-  {
-    nome: 'Personalizados',
-    habitos: []
-  },
-  {
-    nome: 'social',
-    habitos: []
-  },
-  {
-    nome: 'Lazer',
-    habitos: []
-  },
-  {
-    nome: 'Atividade física',
-    habitos: []
-  },
-  {
-    nome: 'sono',
-    habitos: []
-  },
-  {
-    nome: 'Alimentação',
-    habitos: []
-  },
-  {
-    nome: 'Saúde',
-    habitos: []
-  },
-  {
-    nome: 'Profissional',
-    habitos: []
-  },
-  {
-    nome: 'Tarefa',
-    habitos: []
-  },
-  {
-    nome: 'Sexo',
-    habitos: []
-  },
-  {
-    nome: 'Vício',
-    habitos: []
-  }
-]
-
 const HabitoLabel = ({ modeDeEdicaoAtivo, href, children }) => {
   if (modeDeEdicaoAtivo) {
     return <Link href={href}>{children}</Link>
@@ -196,7 +149,7 @@ const HabitosCheckboxGroup: FC<IHabitosCheckboxGroupProps> = ({
     getGrupoDeHabitosTemplate()
   }, [])
 
-  const handleChange = ({ nomeDoGrupo, habito, checked }) => {
+  const handleChange = ({ idDoGrupo, nomeDoGrupo, habito, checked }) => {
     // Clona grupos de hábitos que estão no values para atualizar a referência (imutábilidade)
     const novosGruposDeHabitos = Array.from(values, value => ({ ...value }))
 
@@ -211,7 +164,9 @@ const HabitosCheckboxGroup: FC<IHabitosCheckboxGroupProps> = ({
     }
 
     const grupoDeHabitosAlterado = novosGruposDeHabitos.find(
-      value => value.nome === nomeDoGrupo
+      value =>
+        value.id === idDoGrupo ||
+        value.nome.toLowerCase() === nomeDoGrupo.toLowerCase()
     )
 
     let habitosAlterados
@@ -219,7 +174,9 @@ const HabitosCheckboxGroup: FC<IHabitosCheckboxGroupProps> = ({
       habitosAlterados = [...grupoDeHabitosAlterado.habitos, habito]
     } else {
       habitosAlterados = grupoDeHabitosAlterado.habitos.filter(
-        value => value.nome !== habito?.nome
+        value =>
+          value.id !== habito?.id ||
+          value.nome.toLowerCase() !== habito?.nome.toLowerCase()
       )
     }
 
@@ -231,15 +188,26 @@ const HabitosCheckboxGroup: FC<IHabitosCheckboxGroupProps> = ({
     return <Loading />
   }
 
-  const handleOnClickEditarGrupo = nomeDoGrupo => {
-    if (gruposEmModoEdicao.includes(nomeDoGrupo)) {
+  const handleOnClickEditarGrupo = (idDoGrupo, nomeDoGrupo) => {
+    if (
+      gruposEmModoEdicao.some(
+        grupoEmModoEdicao =>
+          grupoEmModoEdicao.id === idDoGrupo ||
+          grupoEmModoEdicao.nome.toLowerCase() === nomeDoGrupo.toLowerCase()
+      )
+    ) {
       const grupoEmModoEdicao = gruposEmModoEdicao.filter(
-        nomeDoGrupoEmEdicao => nomeDoGrupoEmEdicao !== nomeDoGrupo
+        grupoEmEdicao =>
+          grupoEmEdicao.id !== idDoGrupo ||
+          grupoEmEdicao.nome.toLowerCase() !== nomeDoGrupo.toLowerCase()
       )
       setGruposEmModoEdicao(grupoEmModoEdicao)
       return
     }
-    setGruposEmModoEdicao([...gruposEmModoEdicao, nomeDoGrupo])
+    setGruposEmModoEdicao([
+      ...gruposEmModoEdicao,
+      { nome: nomeDoGrupo, id: idDoGrupo }
+    ])
   }
 
   return (
@@ -247,9 +215,16 @@ const HabitosCheckboxGroup: FC<IHabitosCheckboxGroupProps> = ({
       <Box display="flex">
         <Box className={classes.container}>
           {gruposDeHabitosTemplate.map(grupo => {
-            const isModoDeEdicaoAtivo = gruposEmModoEdicao.includes(grupo.nome)
+            const isModoDeEdicaoAtivo = gruposEmModoEdicao.some(
+              grupoEmModoEdicao =>
+                grupoEmModoEdicao.id === grupo.id ||
+                grupoEmModoEdicao.nome.toLowerCase() ===
+                  grupo.nome.toLowerCase()
+            )
             const indexGrupo = values.findIndex(
-              value => value.nome === grupo.nome
+              value =>
+                value.id === grupo.id ||
+                value.nome.toLowerCase() === grupo.nome.toLowerCase()
             )
             return (
               <Box className={classes.grupo} key={`nome-habito-${grupo.nome}`}>
@@ -269,7 +244,9 @@ const HabitosCheckboxGroup: FC<IHabitosCheckboxGroupProps> = ({
                       <MaterialUiLink
                         href="#"
                         component="button"
-                        onClick={() => handleOnClickEditarGrupo(grupo.nome)}
+                        onClick={() =>
+                          handleOnClickEditarGrupo(grupo.id, grupo.nome)
+                        }
                         style={{ position: 'initial' }}
                         underline="none"
                       >
@@ -310,6 +287,7 @@ const HabitosCheckboxGroup: FC<IHabitosCheckboxGroupProps> = ({
                         color="primary"
                         onChange={event =>
                           handleChange({
+                            idDoGrupo: grupo.id,
                             nomeDoGrupo: grupo.nome,
                             habito: habito,
                             checked: event.target.checked

--- a/src/pages/app/diario/[date]/habitos/index.tsx
+++ b/src/pages/app/diario/[date]/habitos/index.tsx
@@ -6,13 +6,11 @@ import { withUser } from '../../../../../components/hocs/withAuth'
 import CreateOrUpdateRegistro from '../../../../../services/registro/CreateOrUpdateRegistro'
 import EdicaoDiario from '../../../../../components/templates/EdicaoDiario'
 import useRegistroByDate from '../../../../../hooks/useRegistroByDate'
-import HabitosCheckboxGroup, {
-  valoresIniciais
-} from '../../../../../components/diario/HabitosCheckboxGroup'
-import { useRouter } from 'next/router'
+import HabitosCheckboxGroup from '../../../../../components/diario/HabitosCheckboxGroup'
 import { analytics } from '../../../../../components/firebase/firebase.config'
 import Novidade from '../../../../../components/Novidade'
 import { IUser } from 'src/entities/User'
+import { getGrupoDeHabitosIniciais } from 'src/utils/getGrupoDeHabitosIniciais'
 
 interface IProps {
   date: string
@@ -21,7 +19,6 @@ interface IProps {
 
 const Habitos: FC<IProps> = ({ date, user }) => {
   const dia = parse(date, 'd-M-yyyy', new Date())
-  const router = useRouter()
   const userId = user?.id
 
   const { loading, registroDoDia } = useRegistroByDate({
@@ -29,7 +26,15 @@ const Habitos: FC<IProps> = ({ date, user }) => {
     date: dia
   })
 
-  const [gruposDeHabitos, setGruposDeHabitos] = useState(valoresIniciais)
+  const [gruposDeHabitos, setGruposDeHabitos] = useState([])
+
+  useEffect(() => {
+    const buscarValoresIniciais = async () => {
+      const valoresIniciais = await getGrupoDeHabitosIniciais(userId)
+      setGruposDeHabitos(valoresIniciais)
+    }
+    buscarValoresIniciais()
+  }, [])
 
   useEffect(() => {
     if (registroDoDia?.gruposDeHabitos?.length > 0) {

--- a/src/repositories/RegistrosRepository.ts
+++ b/src/repositories/RegistrosRepository.ts
@@ -98,14 +98,16 @@ export default class RegistrosRepository implements IRegistrosRepository {
         ).map(grupoDehabito => {
           const grupoDeHabitoDoUsuario = gruposdeHabitosTemplate.find(
             grupoDehabitoDoTemplate =>
-              grupoDehabitoDoTemplate.nome === grupoDehabito.nome
+              grupoDehabitoDoTemplate.nome.toLowerCase() ===
+                grupoDehabito.nome.toLowerCase() ||
+              grupoDehabitoDoTemplate.id === grupoDehabito.id
           )
           const habitos = grupoDehabito.habitos.map(habito => {
             return (
               grupoDeHabitoDoUsuario.habitos.find(
                 habitoDoUsuario =>
                   habitoDoUsuario.id === habito ||
-                  habitoDoUsuario.nome === habito
+                  habitoDoUsuario.nome.toLowerCase() === habito.toLowerCase()
               ) ||
               habitosPersonalizadosDoUsuario.find(
                 habitoPersonalizado => habitoPersonalizado.id === habito
@@ -113,6 +115,7 @@ export default class RegistrosRepository implements IRegistrosRepository {
             )
           })
           return new GrupoDeHabitos({
+            id: grupoDeHabitoDoUsuario.id || '',
             nome: grupoDehabito.nome,
             habitos: habitos
           })

--- a/src/services/registro/CreateOrUpdateRegistro.ts
+++ b/src/services/registro/CreateOrUpdateRegistro.ts
@@ -37,6 +37,7 @@ export default class CreateOrUpdate implements ICreateOrUpdate {
           habito => habito.id || habito.nome
         )
         parsedAttributes.gruposDeHabitos.push({
+          id: grupoDeHabitos.id || '',
           nome: grupoDeHabitos.nome,
           habitos
         })

--- a/src/utils/getGrupoDeHabitosIniciais.ts
+++ b/src/utils/getGrupoDeHabitosIniciais.ts
@@ -1,0 +1,20 @@
+import GetGrupoDeHabitosTemplateByUserId from 'src/services/grupoDehabitos/GetGrupoDeHabitosTemplateByUserId'
+import GetAllGruposDeHaBitosModelos from 'src/services/grupoDehabitos/GetAllGruposDeHabitosModelos'
+
+export const getGrupoDeHabitosIniciais = async (userId?: string) => {
+  let gruposDeHabitosIniciais = []
+  if (userId) {
+    gruposDeHabitosIniciais = await new GetGrupoDeHabitosTemplateByUserId().call(
+      {
+        userId
+      }
+    )
+  } else {
+    gruposDeHabitosIniciais = await new GetAllGruposDeHaBitosModelos().call()
+  }
+  return gruposDeHabitosIniciais.map(grupoDeHabitos => ({
+    nome: grupoDeHabitos.nome,
+    id: userId && grupoDeHabitos.id !== null ? grupoDeHabitos.id : '',
+    habitos: []
+  }))
+}


### PR DESCRIPTION
## O que esse PR altera?
- Ao marcar os habitos no registro de hábitos passa a salvar também o id do grupo de hábito do usuário, caso esse possua. Se não existir grupo de hábito do usuário é salvo o campo id com string vazia.
- Adiciona uma função `getGrupoDeHabitosIniciais` que monta os grupos de hábitos iniciais, tanto no  momento do cadastro, quanto no primeiro registro de cada dia
    -  Se usuário possuir grupo, usa os grupos do usuário
    - Se não possuir usa os grupos modelos
 - Altera o cadastro do usuário (`UserRepository`) para, antes de salvar o primeiro registro do diário (`CreateOrUpdateRegistro`), alterar o grupo de hábitos adicionando os ids dos grupos e dos hábitos do usuário, criados no momento desse cadastro.
 
## Como testar
1. Com usuário existente
- Acessar o diário com um usuário já cadastrado e que não possua gruposDeHabitos na collection user
- Acessar hábitos, marcar alguns hábitos e salvar o registro. Na collection diarios o registro desse dia, para esse usuário, no campo gruposDeHabitos deve listar os nomes dos hábitos marcados. Exceto para hábitos do grupo Personalizados. e no campo id deve estar uma string vazia. Ex:
![image](https://user-images.githubusercontent.com/13313889/125662098-e4036157-8716-4ae4-858e-078913e13521.png)

2. Com usuário novo
- Acessar o app e cadastra um novo usuário
- Na collection user, no documento desse usuário, deve existir uma subcollection gruposDeHabitos com uma subcollection habitos para cadas grupo
- Acessar hábitos, marcar alguns hábitos e salvar o registro. Na collection diarios o registro desse dia, para esse usuário, no campo gruposDeHabitos deve listar os **_ids_** dos hábitos marcados e os  **_ids_**  dos grupos. Ex: 
![image](https://user-images.githubusercontent.com/13313889/125662263-c25514dd-0a66-4cb2-8f29-5e582e529570.png)

Closes #178880765