### PR TITLE
function: Migrar todos os registros do diario com o id ao invés do nome 

### DIFF
--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -4,12 +4,14 @@ import {createGruposDeHabitosModelos} from "./createGruposDeHabitosModelos";
 import {createSentimentosModelos} from "./createSentimentosModelos";
 import {preencheGruposDeHabitosUsers} from "./preencheGruposDeHabitosUsers";
 import {migrarHabitosPersonalizados} from "./migrarHabitosPersonalizados";
+import {migrarRegistrosHabitos} from "./migrarRegistrosHabitos";
 import * as admin from "firebase-admin";
 
 admin.initializeApp();
 
 export {
   migrarHabitosPersonalizados,
+  migrarRegistrosHabitos,
   createSentimentosModelos,
   createGruposDeHabitosModelos,
   preencheGruposDeHabitosUsers

--- a/functions/src/migrarHabitosPersonalizados.ts
+++ b/functions/src/migrarHabitosPersonalizados.ts
@@ -1,14 +1,7 @@
 
 import * as functions from "firebase-functions";
 import * as admin from "firebase-admin";
-
-type Habito = {
-  id?: string;
-  userId?: string;
-  nome: string;
-  emojiUnicode: string | Array<string>;
-  posicao: number;
-}
+import { Habito } from "./types/Habito";
 
 /**
  * Função para migrar os hábitos da collection `habitos`

--- a/functions/src/migrarRegistrosHabitos.ts
+++ b/functions/src/migrarRegistrosHabitos.ts
@@ -14,62 +14,31 @@ export const migrarRegistrosHabitos = functions.https.onRequest(
     let updatedUsers = 0 // Contador para exibir no retorno
     let updatedDiarios = 0 // Contador para exibir no retorno
 
-    // Passa por todos os usuários
+    const userIdParam = request.query?.userid;
     const usersCollection = admin.firestore().collection("user")
-    const snapshotUsers = await usersCollection.get()
     const usersId: Array<string> = []
-    snapshotUsers.forEach(userSnap => {
-      usersId.push(userSnap.id)
-    })
+    if (userIdParam) {
+      // Filtro por usuário
+      functions.logger.info(`Iniciando migração para único usuário ${userIdParam}`)
+      usersId.push(String(userIdParam))
+    } else {
+      // Passa por todos os usuários, e adiciona os que 
+      // ainda não foram migrados ao array usersId
+      const snapshotUsers = await usersCollection.get() 
+      snapshotUsers.forEach(userSnap => {
+        const { registroMigrado } = userSnap.data()
+        if (!registroMigrado) {
+          usersId.push(userSnap.id)
+        }
+      })
+    }
 
+    functions.logger.info("migração dos usuários", usersId)
     for (const userId of usersId) {
       functions.logger.info(`iniciando Migração de registros para o user ${userId}`)
       if(!userId) {
-        return
+        continue
       }
-      // Monta um array indexado pelo nome dos grupos e habitos
-      // eslint-disable-next-line prefer-const
-      let gruposIdByNome: Map<string, string> = new Map<string, string>()
-      const habitosIdByNome: Map<string, string> = new Map<string, string>()
-      const snapshotGrupos = await admin
-        .firestore()
-        .collection(`user/${userId}/gruposDeHabitos`)
-        .get()
-
-      if (snapshotGrupos.empty) {
-        functions.logger.info("sem gruposDeHabitos", { snapshotGrupos })
-        return
-      }
-
-      // monta aray de grupos
-      snapshotGrupos.forEach(grupoHabitoSnap => {
-        const grupoHabito = grupoHabitoSnap.data() as GrupoDeHabitos
-        gruposIdByNome.set(grupoHabito.nome.toLowerCase(), grupoHabitoSnap.id)
-      })
-      functions.logger.info("gruposIdByNome", gruposIdByNome)
-
-      // monta array de habitos com base nos grupos
-      for (const grupoHabitoId of gruposIdByNome.values()) {
-        const snapshotHabitosUsuario = await admin
-          .firestore()
-          .collection(`user/${userId}/gruposDeHabitos/${grupoHabitoId}/habitos`)
-          .get()
-        if (snapshotHabitosUsuario.empty) {
-          functions.logger.info(`user/${userId}/gruposDeHabitos/${grupoHabitoId}/habitos: sem hábitos registrados`);
-        } else {
-          functions.logger.info(`user/${userId}/gruposDeHabitos/${grupoHabitoId}/habitos: iniciando map`);
-          snapshotHabitosUsuario.forEach(habitoUsuarioSnap => {
-            const habitoUsuario = habitoUsuarioSnap.data()
-            functions.logger.info("map habito", habitoUsuario);
-            habitosIdByNome.set(
-              habitoUsuario.nome.toLowerCase(),
-              habitoUsuarioSnap.id
-            )
-          })
-        } 
-      }
-      functions.logger.info("habitosIdByNome", habitosIdByNome)
-
       // Passa por todos os registros desse usuario
       const diarioCollection = admin.firestore().collection("diario")
       const snapshotDiario = await diarioCollection
@@ -78,12 +47,52 @@ export const migrarRegistrosHabitos = functions.https.onRequest(
       if (snapshotDiario.empty) {
         functions.logger.info(`user ${userId} sem registros no diario`);
       } else {
+        // Monta um array indexado pelo nome dos grupos e habitos
+        // eslint-disable-next-line prefer-const
+        let gruposIdByNome: Map<string, string> = new Map<string, string>()
+        const habitosIdByNome: Map<string, string> = new Map<string, string>()
+        const snapshotGrupos = await admin
+          .firestore()
+          .collection(`user/${userId}/gruposDeHabitos`)
+          .get()
+
+        if (snapshotGrupos.empty) {
+          functions.logger.info(`user ${userId} sem gruposDeHabitos`);
+          continue
+        }
+
+        // monta aray de grupos
+        snapshotGrupos.forEach(grupoHabitoSnap => {
+          const grupoHabito = grupoHabitoSnap.data() as GrupoDeHabitos
+          gruposIdByNome.set(grupoHabito.nome.toLowerCase(), grupoHabitoSnap.id)
+        })
+        functions.logger.info("gruposIdByNome", gruposIdByNome)
+
+        // monta array de habitos com base nos grupos
+        for (const grupoHabitoId of gruposIdByNome.values()) {
+          const snapshotHabitosUsuario = await admin
+            .firestore()
+            .collection(`user/${userId}/gruposDeHabitos/${grupoHabitoId}/habitos`)
+            .get()
+          if (snapshotHabitosUsuario.empty) {
+            functions.logger.info(`user/${userId}/gruposDeHabitos/${grupoHabitoId}/habitos: sem hábitos registrados`);
+          } else {
+            snapshotHabitosUsuario.forEach(habitoUsuarioSnap => {
+              const habitoUsuario = habitoUsuarioSnap.data()
+              habitosIdByNome.set(
+                habitoUsuario.nome.toLowerCase(),
+                habitoUsuarioSnap.id
+              )
+            })
+          } 
+        }
+        functions.logger.info("habitosIdByNome", habitosIdByNome)
+
         snapshotDiario.forEach(diarioSnap => {
           const { id } = diarioSnap
           const diario = diarioSnap.data()
-          const { gruposDeHabitos } = diario
-          functions.logger.info(`user ${userId}, grupo de habitos antigo`, gruposDeHabitos);
-          if (!gruposDeHabitos) {
+          const { gruposDeHabitos, registroMigrado } = diario
+          if (!gruposDeHabitos || registroMigrado) {
             return
           }
           // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -109,14 +118,15 @@ export const migrarRegistrosHabitos = functions.https.onRequest(
               habitos: novosHabitos
             }
           })
-          functions.logger.info("novoGrupoDeHabitos", novoGrupoDeHabitos)
           // Atualiza no banco
-          admin
           diarioCollection
             .doc(id)
-            .set({ gruposDeHabitos: novoGrupoDeHabitos }, { merge: true })
+            .set({ gruposDeHabitos: novoGrupoDeHabitos, registroMigrado: true }, { merge: true })
           updatedDiarios++
         })
+        usersCollection
+          .doc(userId)
+          .set({ registrosMigrados: true }, { merge: true })
         updatedUsers++
       } 
     }

--- a/functions/src/migrarRegistrosHabitos.ts
+++ b/functions/src/migrarRegistrosHabitos.ts
@@ -1,84 +1,104 @@
-
-import * as functions from "firebase-functions";
-import * as admin from "firebase-admin";
-import { GrupoDeHabitos } from "./types/GrupoDeHabitos";
+import * as functions from 'firebase-functions'
+import * as admin from 'firebase-admin'
+import { GrupoDeHabitos } from './types/GrupoDeHabitos'
 
 /**
- * Função para alterar os registros de todos os hábitos
- * trocando o nome do hábito pelo id que ele possui na 
- * collection de modelos, tanto de hábitos como de grupos de hábitos
+ * Função para alterar os registros do diário trocando
+ * o nome do hábito pelo id que ele possui na collection
+ * de habitos pertencente ao usuário, isso tanto para os
+ * hábitos como para os grupos de hábitos
  */
-export const migrarRegistrosHabitos = functions.https.onRequest(async (request, response) => {
-  
-  // Monta um array indexado pelo nome dos grupos e habitos
-  // eslint-disable-next-line prefer-const
-  let gruposIdByNome: Map<string, string> = new Map<string, string>()
-  const habitosIdByNome: Map<string, string> = new Map<string, string>()
-  const snapshotGruposModelo = await admin.firestore().collection("gruposDeHabitosModelos").get();
-  if (snapshotGruposModelo.empty) {
-    functions.logger.info("sem gruposDeHabitos", { snapshotGruposModelo });
-    return 
-  } 
+export const migrarRegistrosHabitos = functions.https.onRequest(
+  async (request, response) => {
+    let updatedUsers = 0 // Contador para exibir no retorno
+    let updatedDiarios = 0 // Contador para exibir no retorno
 
-  // monta aray de grupos
-  snapshotGruposModelo.forEach(grupoModeloSnap => {
-    const grupoModelo = grupoModeloSnap.data() as GrupoDeHabitos
-    gruposIdByNome.set(grupoModelo.nome.toLowerCase(), grupoModeloSnap.id)
-  })
-  functions.logger.info("gruposIdByNome", gruposIdByNome);
+    // Passa por todos os usuários
+    const usersCollection = admin.firestore().collection('user')
+    const snapshotUsers = await usersCollection.get()
+    const usersId: Array<string> = []
+    snapshotUsers.forEach(userSnap => {
+      usersId.push(userSnap.id)
+    })
 
-  // monta array de habitos com base nos grupos
-  for(const grupoModeloId of gruposIdByNome.values()) {
-    const snapshotHabitosModelo = await admin
-      .firestore()
-      .collection(`gruposDeHabitosModelos/${grupoModeloId}/habitosModelos`)
-      .get()
-    snapshotHabitosModelo.forEach(habitoModeloSnap => {
-      const habitoModelo = habitoModeloSnap.data()
-      habitosIdByNome.set(habitoModelo.nome.toLowerCase(), habitoModeloSnap.id)
+    for (const userId of usersId) {
+      // Monta um array indexado pelo nome dos grupos e habitos
+      // eslint-disable-next-line prefer-const
+      let gruposIdByNome: Map<string, string> = new Map<string, string>()
+      const habitosIdByNome: Map<string, string> = new Map<string, string>()
+      const snapshotGrupos = await admin
+        .firestore()
+        .collection(`user/${userId}/gruposDeHabitos`)
+        .get()
+
+      if (snapshotGrupos.empty) {
+        functions.logger.info('sem gruposDeHabitos', { snapshotGrupos })
+        return
+      }
+
+      // monta aray de grupos
+      snapshotGrupos.forEach(grupoHabitoSnap => {
+        const grupoHabito = grupoHabitoSnap.data() as GrupoDeHabitos
+        gruposIdByNome.set(grupoHabito.nome.toLowerCase(), grupoHabitoSnap.id)
+      })
+      functions.logger.info('gruposIdByNome', gruposIdByNome)
+
+      // monta array de habitos com base nos grupos
+      for (const grupoHabitoId of gruposIdByNome.values()) {
+        const snapshotHabitosUsuario = await admin
+          .firestore()
+          .collection(`user/${userId}/gruposDeHabitos/${grupoHabitoId}/habitos`)
+          .get()
+        snapshotHabitosUsuario.forEach(habitoUsuarioSnap => {
+          const habitoUsuario = habitoUsuarioSnap.data()
+          habitosIdByNome.set(
+            habitoUsuario.nome.toLowerCase(),
+            habitoUsuarioSnap.id
+          )
+        })
+      }
+      functions.logger.info('habitosIdByNome', habitosIdByNome)
+
+      // Passa por todos os registros desse usuario
+      const diarioCollection = admin.firestore().collection('diario')
+      const snapshotDiario = await diarioCollection
+        .where('userId', '==', userId)
+        .get()
+      snapshotDiario.forEach(diarioSnap => {
+        const { id } = diarioSnap
+        const diario = diarioSnap.data()
+        const { gruposDeHabitos } = diario
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        const novoGrupoDeHabitos = gruposDeHabitos.map((grupo: any) => {
+          const { nome, habitos } = grupo
+          const idGrupo = gruposIdByNome.get(nome.toLowerCase()) || ''
+          if (!habitos || habitos.length === 0) {
+            return {
+              nome,
+              id: idGrupo
+            }
+          }
+          const novosHabitos = habitos?.map((habitoNome: string) =>
+            habitosIdByNome.get(habitoNome.toLowerCase())
+          )
+          return {
+            nome,
+            id: idGrupo,
+            habitos: novosHabitos
+          }
+        })
+        functions.logger.info('novoGrupoDeHabitos', novoGrupoDeHabitos)
+        // Atualiza no banco
+        admin
+        diarioCollection
+          .doc(id)
+          .set({ gruposDeHabitos: novoGrupoDeHabitos }, { merge: true })
+        updatedDiarios++
+      })
+      updatedUsers++
+    }
+    response.send({
+      message: `Foram alterado ${updatedDiarios} registros de diário de ${updatedUsers} usuários`
     })
   }
-  functions.logger.info("habitosIdByNome", habitosIdByNome);
-
-  
-  // Passa por todos os registros
-  const diarioCollection = admin.firestore().collection("diario")
-  const snapshotDiario = await diarioCollection.get()
-  snapshotDiario.forEach(diarioSnap => {
-    const { id } = diarioSnap
-    const diario = diarioSnap.data()
-    const { gruposDeHabitos } = diario
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const novoGrupoDeHabitos = gruposDeHabitos.map((grupo : any) => {
-      const { nome, habitos } = grupo
-      const idGrupo = gruposIdByNome.get(nome.toLowerCase()) || ""
-      if (!habitos || habitos.length === 0) {
-        return {
-          nome,
-          id: idGrupo
-        }
-      }
-      const novosHabitos = habitos?.map((habitoNome: string) => 
-        habitosIdByNome.get(habitoNome.toLowerCase())
-      )
-      return {
-        nome,
-        id: idGrupo,
-        habitos: novosHabitos
-      }
-    })
-    functions.logger.info("novoGrupoDeHabitos", novoGrupoDeHabitos);
-    // Atualiza no banco
-    admin
-      diarioCollection
-      .doc(id)
-      .set(
-        { gruposDeHabitos: novoGrupoDeHabitos },
-        {merge: true}
-      );
-  })
-  
-
-  response.send({ message: "grupos de hábitos e hábitos migrados", gruposIdByNome });
-
-})
+)

--- a/functions/src/migrarRegistrosHabitos.ts
+++ b/functions/src/migrarRegistrosHabitos.ts
@@ -1,6 +1,6 @@
-import * as functions from 'firebase-functions'
-import * as admin from 'firebase-admin'
-import { GrupoDeHabitos } from './types/GrupoDeHabitos'
+import * as functions from "firebase-functions"
+import * as admin from "firebase-admin"
+import { GrupoDeHabitos } from "./types/GrupoDeHabitos"
 
 /**
  * Função para alterar os registros do diário trocando
@@ -14,7 +14,7 @@ export const migrarRegistrosHabitos = functions.https.onRequest(
     let updatedDiarios = 0 // Contador para exibir no retorno
 
     // Passa por todos os usuários
-    const usersCollection = admin.firestore().collection('user')
+    const usersCollection = admin.firestore().collection("user")
     const snapshotUsers = await usersCollection.get()
     const usersId: Array<string> = []
     snapshotUsers.forEach(userSnap => {
@@ -32,7 +32,7 @@ export const migrarRegistrosHabitos = functions.https.onRequest(
         .get()
 
       if (snapshotGrupos.empty) {
-        functions.logger.info('sem gruposDeHabitos', { snapshotGrupos })
+        functions.logger.info("sem gruposDeHabitos", { snapshotGrupos })
         return
       }
 
@@ -41,7 +41,7 @@ export const migrarRegistrosHabitos = functions.https.onRequest(
         const grupoHabito = grupoHabitoSnap.data() as GrupoDeHabitos
         gruposIdByNome.set(grupoHabito.nome.toLowerCase(), grupoHabitoSnap.id)
       })
-      functions.logger.info('gruposIdByNome', gruposIdByNome)
+      functions.logger.info("gruposIdByNome", gruposIdByNome)
 
       // monta array de habitos com base nos grupos
       for (const grupoHabitoId of gruposIdByNome.values()) {
@@ -57,12 +57,12 @@ export const migrarRegistrosHabitos = functions.https.onRequest(
           )
         })
       }
-      functions.logger.info('habitosIdByNome', habitosIdByNome)
+      functions.logger.info("habitosIdByNome", habitosIdByNome)
 
       // Passa por todos os registros desse usuario
-      const diarioCollection = admin.firestore().collection('diario')
+      const diarioCollection = admin.firestore().collection("diario")
       const snapshotDiario = await diarioCollection
-        .where('userId', '==', userId)
+        .where("userId", "==", userId)
         .get()
       snapshotDiario.forEach(diarioSnap => {
         const { id } = diarioSnap
@@ -71,7 +71,7 @@ export const migrarRegistrosHabitos = functions.https.onRequest(
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         const novoGrupoDeHabitos = gruposDeHabitos.map((grupo: any) => {
           const { nome, habitos } = grupo
-          const idGrupo = gruposIdByNome.get(nome.toLowerCase()) || ''
+          const idGrupo = gruposIdByNome.get(nome.toLowerCase()) || ""
           if (!habitos || habitos.length === 0) {
             return {
               nome,
@@ -87,7 +87,7 @@ export const migrarRegistrosHabitos = functions.https.onRequest(
             habitos: novosHabitos
           }
         })
-        functions.logger.info('novoGrupoDeHabitos', novoGrupoDeHabitos)
+        functions.logger.info("novoGrupoDeHabitos", novoGrupoDeHabitos)
         // Atualiza no banco
         admin
         diarioCollection

--- a/functions/src/migrarRegistrosHabitos.ts
+++ b/functions/src/migrarRegistrosHabitos.ts
@@ -1,0 +1,84 @@
+
+import * as functions from "firebase-functions";
+import * as admin from "firebase-admin";
+import { GrupoDeHabitos } from "./types/GrupoDeHabitos";
+
+/**
+ * Função para alterar os registros de todos os hábitos
+ * trocando o nome do hábito pelo id que ele possui na 
+ * collection de modelos, tanto de hábitos como de grupos de hábitos
+ */
+export const migrarRegistrosHabitos = functions.https.onRequest(async (request, response) => {
+  
+  // Monta um array indexado pelo nome dos grupos e habitos
+  // eslint-disable-next-line prefer-const
+  let gruposIdByNome: Map<string, string> = new Map<string, string>()
+  const habitosIdByNome: Map<string, string> = new Map<string, string>()
+  const snapshotGruposModelo = await admin.firestore().collection("gruposDeHabitosModelos").get();
+  if (snapshotGruposModelo.empty) {
+    functions.logger.info("sem gruposDeHabitos", { snapshotGruposModelo });
+    return 
+  } 
+
+  // monta aray de grupos
+  snapshotGruposModelo.forEach(grupoModeloSnap => {
+    const grupoModelo = grupoModeloSnap.data() as GrupoDeHabitos
+    gruposIdByNome.set(grupoModelo.nome.toLowerCase(), grupoModeloSnap.id)
+  })
+  functions.logger.info("gruposIdByNome", gruposIdByNome);
+
+  // monta array de habitos com base nos grupos
+  for(const grupoModeloId of gruposIdByNome.values()) {
+    const snapshotHabitosModelo = await admin
+      .firestore()
+      .collection(`gruposDeHabitosModelos/${grupoModeloId}/habitosModelos`)
+      .get()
+    snapshotHabitosModelo.forEach(habitoModeloSnap => {
+      const habitoModelo = habitoModeloSnap.data()
+      habitosIdByNome.set(habitoModelo.nome.toLowerCase(), habitoModeloSnap.id)
+    })
+  }
+  functions.logger.info("habitosIdByNome", habitosIdByNome);
+
+  
+  // Passa por todos os registros
+  const diarioCollection = admin.firestore().collection("diario")
+  const snapshotDiario = await diarioCollection.get()
+  snapshotDiario.forEach(diarioSnap => {
+    const { id } = diarioSnap
+    const diario = diarioSnap.data()
+    const { gruposDeHabitos } = diario
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const novoGrupoDeHabitos = gruposDeHabitos.map((grupo : any) => {
+      const { nome, habitos } = grupo
+      const idGrupo = gruposIdByNome.get(nome.toLowerCase()) || ""
+      if (!habitos || habitos.length === 0) {
+        return {
+          nome,
+          id: idGrupo
+        }
+      }
+      const novosHabitos = habitos?.map((habitoNome: string) => 
+        habitosIdByNome.get(habitoNome.toLowerCase())
+      )
+      return {
+        nome,
+        id: idGrupo,
+        habitos: novosHabitos
+      }
+    })
+    functions.logger.info("novoGrupoDeHabitos", novoGrupoDeHabitos);
+    // Atualiza no banco
+    admin
+      diarioCollection
+      .doc(id)
+      .set(
+        { gruposDeHabitos: novoGrupoDeHabitos },
+        {merge: true}
+      );
+  })
+  
+
+  response.send({ message: "grupos de hábitos e hábitos migrados", gruposIdByNome });
+
+})

--- a/functions/src/preencheGruposDeHabitosUsers.ts
+++ b/functions/src/preencheGruposDeHabitosUsers.ts
@@ -1,13 +1,7 @@
 
 import * as functions from "firebase-functions";
 import * as admin from "firebase-admin";
-
-type Habito = {
-  id?: string;
-  nome: string;
-  emojiUnicode: string | Array<string>;
-  posicao: number;
-}
+import { Habito } from "./types/Habito";
 
 /**
  * Função para copiar todos os hábitos da collection `gruposDeHabitosModelos`

--- a/functions/src/preencheGruposDeHabitosUsers.ts
+++ b/functions/src/preencheGruposDeHabitosUsers.ts
@@ -37,32 +37,37 @@ export const preencheGruposDeHabitosUsers = functions.https.onRequest(async (req
     })
   }
 
+  functions.logger.info("gruposModelo", { gruposDeHabitos })
 
   const usersCollection = admin.firestore().collection("user")
   const snapshotUsers = await usersCollection.get()
+  const usersId: Array<string> = []
+  snapshotUsers.forEach(userSnap => {
+    usersId.push(userSnap.id)
+  })
+
+  for (const userId of usersId) {
   // Percorre todos os usuários
-  snapshotUsers.forEach(async userSnap => {
-    const userId = userSnap.id
     const snapshotGruposUser = await admin
       .firestore()
       .collection(`user/${userId}/gruposDeHabitos`)
       .get()
     // Caso não tenha grupoDeHabitos, insere hábitos
     if (snapshotGruposUser.empty) {
-      const user = userSnap.data()
-      functions.logger.info("user sem grupos", { user })
-      gruposDeHabitos.forEach(async grupo => {
+      for (const grupo of gruposDeHabitos) {
+        functions.logger.info(`inserindo grupo no user ${userId}`, { grupo })
         const { habitos, id, ...grupoProps } = grupo
         const grupoRef = await usersCollection.doc(userId).collection("gruposDeHabitos").add({ ...grupoProps, idDoGrupoModelo: id })
+        functions.logger.info(`inserindo habitos no user ${userId}`, { habitos })
         habitos.forEach(({ id, ...habito }: Habito) => {
           admin
             .firestore()
             .collection(`user/${userId}/gruposDeHabitos/${grupoRef.id}/habitos`)
             .add({ ...habito, idDoHabitoModelo: id })
         })
-      })
+      }
     }
-  })
+  }
 
   response.send({ message: "grupos de hábitos adicionados", gruposDeHabitos });
 });

--- a/functions/src/types/GrupoDeHabitos.ts
+++ b/functions/src/types/GrupoDeHabitos.ts
@@ -1,0 +1,9 @@
+import { Habito } from "./Habito";
+
+export type GrupoDeHabitos = {
+  id?: string;
+  nome: string;
+  posicao?: number;
+  habitos?: Array<Habito> | Array<string>
+  habitosModelo?: Array<Habito>
+}

--- a/functions/src/types/Habito.ts
+++ b/functions/src/types/Habito.ts
@@ -1,0 +1,7 @@
+export type Habito = {
+  id?: string;
+  userId?: string;
+  nome: string;
+  emojiUnicode: string | Array<string>;
+  posicao: number;
+}


### PR DESCRIPTION
Função `migrarResitrosHabitos` criada para alterar os registros de todos os hábitos trocando o nome do hábito pelo id que ele possui na  collection de modelos, tanto de hábitos como de grupos de hábitos
Essa função não considera quem é o usuário daquele registro ou os hábitos já personalizados

Finishes #178378518